### PR TITLE
Improve cotizacion product tables layout

### DIFF
--- a/website_pages_controlador/__manifest__.py
+++ b/website_pages_controlador/__manifest__.py
@@ -34,6 +34,7 @@
         ],
         'web.assets_backend': [
             'website_pages_controlador/static/src/scss/category_rule.scss',
+            'website_pages_controlador/static/src/scss/cotizacion.scss',
         ],
     },
     'installable': True,

--- a/website_pages_controlador/models/cotizacion.py
+++ b/website_pages_controlador/models/cotizacion.py
@@ -25,22 +25,6 @@ class WebsiteConstructorCotizacion(models.Model):
         ('asignado', 'Asignado'),
     ], string='Estado', default='pendiente')
     sale_order_id = fields.Many2one('sale.order', string='Pedido de Venta', readonly=True)
-    message_main_attachment_id = fields.Many2one(
-        'ir.attachment',
-        string='Main Attachment',
-        compute='_compute_message_main_attachment_id',
-        inverse='_inverse_message_main_attachment_id',
-        index=True,
-    )
-
-    def _compute_message_main_attachment_id(self):
-        """Delegate computation to ``mail.thread`` implementation."""
-        super()._compute_message_main_attachment_id()
-
-    def _inverse_message_main_attachment_id(self):
-        """Delegate inverse handling to ``mail.thread`` implementation."""
-        super()._inverse_message_main_attachment_id()
-
     @api.depends('producto_ids')
     def _compute_total(self):
         for record in self:

--- a/website_pages_controlador/static/src/scss/cotizacion.scss
+++ b/website_pages_controlador/static/src/scss/cotizacion.scss
@@ -1,0 +1,23 @@
+.o_form_view .o_cotizacion_productos_table,
+.o_form_view .o_cotizacion_productos_sin_stock {
+    width: 100%;
+    display: block;
+}
+
+.o_form_view .o_cotizacion_productos_table .o_list_view,
+.o_form_view .o_cotizacion_productos_sin_stock .o_list_view {
+    width: 100%;
+    min-height: 200px;
+}
+
+.o_form_view .o_cotizacion_productos_table .o_list_view table,
+.o_form_view .o_cotizacion_productos_sin_stock .o_list_view table {
+    width: 100%;
+}
+
+.o_form_view .o_cotizacion_productos_table .o_list_view td,
+.o_form_view .o_cotizacion_productos_table .o_list_view th,
+.o_form_view .o_cotizacion_productos_sin_stock .o_list_view td,
+.o_form_view .o_cotizacion_productos_sin_stock .o_list_view th {
+    white-space: normal;
+}

--- a/website_pages_controlador/views/cotizacion_views.xml
+++ b/website_pages_controlador/views/cotizacion_views.xml
@@ -37,21 +37,6 @@
                         <field name="fecha" nolabel="1"/>
                         <label for="state" string="Estado:"/>
                         <field name="state" readonly="1" nolabel="1"/>
-                        <label for="producto_ids" string="Productos:" colspan="2"/>
-                        <field name="producto_ids" nolabel="1" options="{'no_open': True}" colspan="2">
-                            <tree>
-                                <field name="name"/>
-                                <field name="qty_available" string="Cantidad disponible" readonly="1"/>
-                                <field name="list_price"/>
-                            </tree>
-                        </field>
-                        <label for="productos_sin_stock_ids" string="Productos sin stock:" colspan="2" attrs="{'invisible': [('productos_sin_stock_ids','=',False)]}"/>
-                        <field name="productos_sin_stock_ids" nolabel="1" colspan="2" attrs="{'invisible': [('productos_sin_stock_ids','=',False)]}" class="oe_inline" style="text-align: left;">
-                            <tree create="0" edit="0">
-                                <field name="name"/>
-                                <field name="qty_available" string="Cantidad disponible" readonly="1"/>
-                            </tree>
-                        </field>
                         <label for="total" string="Precio total:" style="font-size: 18px; font-weight: bold;"/>
                         <field name="total" nolabel="1" readonly="1" style="font-size: 18px; font-weight: bold;"/>
                         <label for="assigned_user_id" string="Asignado a:"/>
@@ -59,8 +44,32 @@
                         <label for="sale_order_id" string="Cotización:" attrs="{'invisible': [('sale_order_id','=',False)]}" style="font-size: 16px; font-weight: bold;"/>
                         <field name="sale_order_id" readonly="1" nolabel="1" attrs="{'invisible': [('sale_order_id','=',False)]}" style="font-size: 16px; font-weight: bold;"/>
                     </group>
+                    <notebook>
+                        <page string="Productos">
+                            <field name="producto_ids" nolabel="1" options="{'no_open': True}" class="o_cotizacion_productos_table">
+                                <tree>
+                                    <field name="name"/>
+                                    <field name="qty_available" string="Cantidad disponible" readonly="1"/>
+                                    <field name="list_price"/>
+                                </tree>
+                            </field>
+                        </page>
+                        <page string="Productos sin stock" attrs="{'invisible': [('productos_sin_stock_ids','=',False)]}">
+                            <field name="productos_sin_stock_ids" nolabel="1" class="o_cotizacion_productos_sin_stock">
+                                <tree create="0" edit="0">
+                                    <field name="name"/>
+                                    <field name="qty_available" string="Cantidad disponible" readonly="1"/>
+                                </tree>
+                            </field>
+                        </page>
+                    </notebook>
                     <field name="is_public" invisible="1"/>
                 </sheet>
+                <div class="oe_chatter">
+                    <field name="message_follower_ids" widget="mail_followers"/>
+                    <field name="activity_ids" widget="mail_activity"/>
+                    <field name="message_ids" widget="mail_thread"/>
+                </div>
             </form>
         </field>
     </record>


### PR DESCRIPTION
## Summary
- move cotizacion product listings into a dedicated notebook for better use of space alongside the chatter
- add backend styling so the product tables expand to the available width and remain readable

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e57bd079e88324b42fa8f091727ea2